### PR TITLE
Downstream Kserve demo with (Caikit + TGIS)

### DIFF
--- a/docs/demo/kserve/.gitignore
+++ b/docs/demo/kserve/.gitignore
@@ -1,0 +1,6 @@
+kserve/
+knative-kserve/
+minio-current.yaml
+minio-secret-current.yaml
+.cache/
+kustomize/

--- a/docs/demo/kserve/KServe_Authorino.md
+++ b/docs/demo/kserve/KServe_Authorino.md
@@ -1,0 +1,1 @@
+# KServe with  Authorino

--- a/docs/demo/kserve/Kserve.md
+++ b/docs/demo/kserve/Kserve.md
@@ -1,0 +1,134 @@
+# KServe with Caikit + TGIS runtime
+
+## Prerequisite
+- Openshift Cluster 
+  - This doc is written based on ROSA cluster
+- CLI tools
+  - oc cli
+
+- Installed operators
+  - [Kiali](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/installing-ossm.html)
+  - [Red Hat OpenShift distributed tracing platform](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/installing-ossm.html)
+  - [Red Hat OpenShift Service Mesh](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/installing-ossm.html)
+    - ServiceMeshControlPlan
+  - [Openshift Serverless](https://docs.openshift.com/serverless/1.29/install/install-serverless-operator.html)
+  - [OpenDataHub](https://opendatahub.io/docs/quick-installation/)
+
+# Reference
+- https://github.com/maistra/odh-manifests/blob/ossm_plugin_templates/enabling-ossm.md
+- https://github.com/ReToCode/knative-kserve#installation-with-istio--mesh
+- https://knative.dev/docs/install/operator/knative-with-operators/#create-the-knative-serving-custom-resource
+- 
+
+# Steps
+~~~
+git clone https://github.com/ReToCode/knative-kserve
+
+# Install Service Mesh operators
+oc apply -f knative-kserve/service-mesh/operators.yaml
+sleep 30
+oc wait --for=condition=ready pod -l name=istio-operator -n openshift-operators --timeout=300s
+oc wait --for=condition=ready pod -l name=jaeger-operator -n openshift-operators --timeout=300s
+oc wait --for=condition=ready pod -l name=kiali-operator -n openshift-operators --timeout=300s
+
+# Create an istio instance
+oc create ns istio-system
+oc apply -f custom-manifests/service-mesh/smcp.yaml
+sleep 15
+oc wait --for=condition=ready pod -l app=istiod -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=prometheus -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=istio-ingressgateway -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=istio-egressgateway -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=jaeger -n istio-system --timeout=300s
+
+# kserve/knative
+oc create ns kserve
+oc create ns kserve-demo
+oc create ns knative-serving
+oc apply -f knative-kserve/service-mesh/smmr.yaml
+oc apply -f knative-kserve/service-mesh/peer-authentication.yaml # we need this because of https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/serving#serverless-domain-mapping-custom-tls-cert_domain-mapping-custom-tls-cert
+
+oc apply -f knative-kserve/serverless/operator.yaml
+sleep 30
+oc wait --for=condition=ready pod -l name=knative-openshift -n openshift-serverless --timeout=300s
+oc wait --for=condition=ready pod -l name=knative-openshift-ingress -n openshift-serverless --timeout=300s
+oc wait --for=condition=ready pod -l name=knative-operator -n openshift-serverless --timeout=300s
+
+# Create a Knative Serving installation
+oc apply -f knative-kserve/serverless/knativeserving-istio.yaml
+sleep 15
+oc wait --for=condition=ready pod -l app=controller -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=net-istio-controller -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=net-istio-webhook -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=autoscaler-hpa -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=domain-mapping -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=webhook -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=activator -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=autoscaler -n knative-serving --timeout=300s
+
+# Generate wildcard cert for a gateway.
+export BASE_DIR=/tmp/certs
+export DOMAIN_NAME=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}' | awk -F'.' '{print $(NF-1)"."$NF}')
+export COMMON_NAME=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}'|sed 's/apps.//')
+
+mkdir ${BASE_DIR}
+## Playbook way
+#git clone git@github.com:Jooho/ansible-cheat-sheet.git
+#cd ansible-cheat-sheet/ansible-playbooks/ansible-playbook-generate-self-signed-cert/
+
+#ansible-playbook ./playbook.yaml -e use_intermediate_cert=false -e cert_commonName=*.$COMMON_NAME -e cert_base_dir=${BASE_DIR} -b  -vvvv
+#cp ${BASE_DIR}/wild.$COMMON_NAME/wild.$COMMON_NAME.cert.pem ${BASE_DIR}/wildcard.crt
+#cp ${BASE_DIR}/wild.$COMMON_NAME/wild.$COMMON_NAME.key.pem ${BASE_DIR}/wildcard.key
+
+## openssl
+openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
+-subj "/O=Example Inc./CN=${DOMAIN_NAME}" \
+-keyout $BASE_DIR/root.key \
+-out $BASE_DIR/root.crt
+
+openssl req -nodes -newkey rsa:2048 \
+-subj "/CN=*.${COMMON_NAME}/O=Example Inc." \
+-keyout $BASE_DIR/wildcard.key \
+-out $BASE_DIR/wildcard.csr
+
+openssl x509 -req -days 365 -set_serial 0 \
+-CA $BASE_DIR/root.crt \
+-CAkey $BASE_DIR/root.key \
+-in $BASE_DIR/wildcard.csr \
+-out $BASE_DIR/wildcard.crt
+
+openssl x509 -in ${BASE_DIR}/wildcard.crt -text
+
+# Create the Knative gateways
+oc create secret tls wildcard-certs --cert=${BASE_DIR}/wildcard.crt --key=${BASE_DIR}/wildcard.key -n istio-system
+oc apply -f custom-manifests/serverless/gateways.yaml
+
+# KServe Kfdef
+git clone --branch manifests git@github.com:Jooho/kserve.git
+rm -rf  custom-manifests/opendatahub/.cache  custom-manifests/opendatahub/kustomize /tmp/odh-manifests.gzip
+tar czvf /tmp/odh-manifests.gzip kserve/opendatahub/odh-manifests
+kfctl build -V -f custom-manifests/opendatahub/kfdef-kserve.yaml -d | oc create -n kserve -f -
+
+# Minio Deploy
+ACCESS_KEY_ID=THEACCESSKEY
+SECRET_ACCESS_KEY=$(openssl rand -hex 32)
+
+oc new-project minio
+sed "s/<accesskey>/$ACCESS_KEY_ID/g"  ./custom-manifests/minio/minio.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" | tee ./minio-current.yaml | oc -n minio apply -f -
+sed "s/<accesskey>/$ACCESS_KEY_ID/g" ./custom-manifests/minio/minio-secret.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" | tee ./minio-secret-current.yaml | oc -n minio apply -f - 
+
+# Create Caikit Serving runtime
+oc project kserve-demo
+oc apply -f ./custom-manifests/caikit/caikit-servingruntime.yaml
+
+# Deploy model
+oc apply -f ./minio-secret-current.yaml 
+oc create -f ./custom-manifests/minio/serviceaccount-minio.yaml
+oc adm policy add-scc-to-user anyuid -z sa -n kserve-demo
+
+oc apply -f ./custom-manifests/caikit/caikit-isvc.yaml -n kserve-demo
+
+# Test
+export KSVC_HOSTNAME=$(oc get ksvc caikit-example-isvc-predictor -o jsonpath='{.status.url}' | cut -d'/' -f3)
+grpcurl -insecure -d '{"text": "At what temperature does liquid Nitrogen boil?"}' -H "mm-model-id: bloom-560m" ${KSVC_HOSTNAME}:443 caikit.runtime.Nlp.NlpService/TextGenerationTaskPredict
+~~~

--- a/docs/demo/kserve/OSSM-enabled.md
+++ b/docs/demo/kserve/OSSM-enabled.md
@@ -1,0 +1,102 @@
+# ODH with OSSM enabled
+
+## Prerequisite
+- Openshift Cluster 
+  - This doc is written based on ROSA cluster
+- CLI tools
+  - oc cli
+
+- Installed operators
+  - [Kiali](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/installing-ossm.html)
+  - [Red Hat OpenShift distributed tracing platform](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/installing-ossm.html)
+  - [Red Hat OpenShift Service Mesh](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/installing-ossm.html)
+    - ServiceMeshControlPlan
+  - [OpenDataHub](https://opendatahub.io/docs/quick-installation/)
+  - [Authorino](https://github.com/Kuadrant/authorino-operator)
+
+## Reference
+- https://github.com/maistra/odh-manifests/blob/ossm_plugin_templates/enabling-ossm.md
+- https://github.com/ReToCode/knative-kserve#installation-with-istio--mesh
+ 
+## Setup pre-requisite
+~~~
+git clone https://github.com/ReToCode/knative-kserve
+
+# Install Service Mesh operators
+oc apply -f knative-kserve/service-mesh/operators.yaml
+sleep 30
+oc wait --for=condition=ready pod -l name=istio-operator -n openshift-operators --timeout=300s
+oc wait --for=condition=ready pod -l name=jaeger-operator -n openshift-operators --timeout=300s
+oc wait --for=condition=ready pod -l name=kiali-operator -n openshift-operators --timeout=300s
+
+# Create an istio instance
+oc create ns istio-system
+oc create ns opendatahub
+oc apply -f custom-manifests/service-mesh/smcp.yaml
+oc apply -f custom-manifests/service-mesh/smmr.yaml
+oc apply -f custom-manifests/service-mesh/peer-authentication.yaml
+
+sleep 15
+oc wait --for=condition=ready pod -l app=istiod -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=prometheus -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=istio-ingressgateway -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=istio-egressgateway -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=jaeger -n istio-system --timeout=300s
+
+# Install Authorino/Opendatahub operator
+oc create -f custom-manifests/authorino/operators.yaml  
+operator-sdk run bundle quay.io/maistra-dev/opendatahub-operator-bundle:v0.0.4 --namespace openshift-operators --timeout 5m0s
+#operator-sdk run bundle quay.io/cgarriso/opendatahub-operator-bundle:dev-0.0.2 --namespace openshift-operators --timeout 5m0s
+sleep 15
+oc wait --for=condition=ready pod -l control-plane=authorino-operator -n openshift-operators --timeout=300s
+oc wait --for=condition=ready pod -l control-plane=controller-manager -n openshift-operators --timeout=300s
+ 
+# Deploy opendatahub ossm
+oc create ns auth-provider
+oc create -f custom-manifests/opendatahub/kfdef-plugins.yaml
+oc wait --for condition=available kfdef --all --timeout 360s -n opendatahub
+oc wait --for condition=ready pod --all --timeout 360s opendatahub
+oc get pods -n opendatahub -o yaml | grep -q istio-proxy || oc get deployments -o name -n opendatahub | xargs -I {} oc rollout restart {} -n opendatahub
+
+# Workaround
+export TOKEN=$(oc whoami -t)
+result=$(oc create -o jsonpath='{.status.audiences[0]}' -f -<<EOF
+apiVersion: authentication.k8s.io/v1
+kind: TokenReview
+spec:
+  token: "$TOKEN"
+  audiences: []
+EOF
+)
+
+kubectl patch authconfig odh-dashboard-protection -n opendatahub --type='json' -p="[{'op': 'replace', 'path': '/spec/identity/0/kubernetes/audiences', 'value': ['${result}']}]"
+oc adm policy add-cluster-role-to-user cluster-admin joe
+
+export ODH_ROUTE=$(oc get route --all-namespaces -l maistra.io/gateway-namespace=opendatahub -o yaml | yq '.items[].spec.host')
+xdg-open https://$ODH_ROUTE > /dev/null 2>&1 &    
+
+
+# Customize ossm
+ oc scale deploy/opendatahub-operator-controller-manager -n openshift-operators --replicas=0
+
+~~~
+
+## Troubleshooting
+`OAuth flow failed`
+~~~
+kubectl logs $(kubectl get pod -l app=oauth-openshift -n openshift-authentication -o name|head -n1) -n openshift-authentication  
+
+kubectl get oauthclient.oauth.openshift.io opendatahub-oauth2-client
+kubectl exec $(kubectl get pods -n istio-system -l app=istio-ingressgateway  -o jsonpath='{.items[*].metadata.name}') -n istio-system -c istio-proxy -- cat /etc/istio/opendatahub-oauth2-tokens/token-secret.yaml
+kubectl get secret opendatahub-oauth2-tokens -n istio-system -o yaml
+
+kubectl rollout restart deployment -n istio-system istio-ingressgateway 
+
+oc create -o yaml -f -<<EOF
+apiVersion: authentication.k8s.io/v1
+kind: TokenReview
+spec:
+  token: "$TOKEN"
+  audiences: []
+EOF
+~~~

--- a/docs/demo/kserve/README.md
+++ b/docs/demo/kserve/README.md
@@ -1,0 +1,12 @@
+# OpenDataHub + KServe + Serverless + ServiceMesh + Authorino
+
+This demo is designed to allow multiple installations, both individually and together.
+(Note - Currently it works fine when installed separately, but not when installed together.)
+
+- [KServe with Caikit + TGIS runtime](./Kserve.md)
+  - This install `Serverless`, `Kserve` and `Caikit+TGIS serving runtime`
+  - It demonstrates it can serve bloom-560m model with kserve using a new LLM runtime
+- [Opendatahub that OSSM enabled ](./OSSM-enabled.md)
+  - This install a `new opendatahub operator(has ossm plugins)`, `Authorino`, `ServiceMesh`.
+  - It demonstrates it can login dashboard through Authorino (without oauth-proxy)
+- [TBD] [Update Kserve to use Authorino to secure ingress.](./KServe_Authorino.md)

--- a/docs/demo/kserve/built-tip.md
+++ b/docs/demo/kserve/built-tip.md
@@ -1,0 +1,14 @@
+# Bootstrap process(optional)
+~~~
+yum -y install git git-lfs
+git lfs install
+git clone https://huggingface.co/bigscience/bloom-560m
+
+python3 -m virtualenv venv
+source venv/bin/activate
+
+git clone https://github.com/Xaenalt/caikit-nlp
+python3.9 -m pip install ./caikit-nlp/   (python 3.11 can not compile)  <pip install ./caikit-nlp>
+cp ../convert.py .
+./convert.py --model-path ./bloom-560m/ --model-save-path ./bloom-560m-caikit
+~~~

--- a/docs/demo/kserve/cleanup.sh
+++ b/docs/demo/kserve/cleanup.sh
@@ -1,0 +1,48 @@
+#/bin/bash
+
+directories="servicemesh serverless authorino"
+# directories="servicemesh serverless authorino opendatahub"  # until this pr merged (https://github.com/bartoszmajsak/opendatahub-operator/tree/kf_ossm_plugin/pkg/kfapp/ossm)
+
+
+oc delete smcp basic -n istio-system --force --grace-period=0
+
+
+for dir in ${directories};
+do
+  echo "Delete ${dir} operator"
+  oc delete -f custom-manifests/${dir}/operators.yaml   
+done
+
+# opendatahub 
+operator-sdk cleanup opendatahub-operator --namespace openshift-operators --timeout 5m0s
+
+oc project openshift-operators
+
+for csv in kiali jaeger servicemesh authorino
+do
+  oc get csv |grep $csv |awk '{print $1}' | xargs oc delete csv  
+done
+
+
+
+
+
+
+# oc delete MutatingWebhookConfiguration istiod-basic-istio-system
+# oc delete MutatingWebhookConfiguration openshift-operators.servicemesh-resources.maistra.io
+# oc delete validatingWebhookConfiguration openshift-operators.servicemesh-resources.maistra.io
+
+# for i in $( oc get crd|grep istio |awk '{print $1}')
+# do
+#   oc delete crd $i
+# done
+
+
+#ossm
+
+# KFDEF=${KFDEF:-odh-mesh}
+
+# kubectl delete kfdef ${KFDEF} -n opendatahub
+# kubectl delete oauthclient.oauth.openshift.io opendatahub-oauth2-client
+# echo "opendatahub auth-provider" | xargs -n 1 kubectl delete ns
+# echo "opendatahub auth-provider" | xargs -n 1 kubectl create ns

--- a/docs/demo/kserve/convert.py
+++ b/docs/demo/kserve/convert.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import caikit_nlp
+import argparse
+
+parser = argparse.ArgumentParser(prog="convert.py")
+parser.add_argument("--model-path", help="Path of the base HuggingFace model", )
+parser.add_argument("--model-save-path", help="Path to save the Caikit format model to")
+
+args = parser.parse_args()
+
+model = caikit_nlp.text_generation.TextGeneration.bootstrap(args.model_path)
+
+model.save(model_path=args.model_save_path)

--- a/docs/demo/kserve/custom-manifests/authorino/operators.yaml
+++ b/docs/demo/kserve/custom-manifests/authorino/operators.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: authorino-operator
+  namespace: openshift-operators
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: authorino-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/docs/demo/kserve/custom-manifests/caikit/caikit-isvc.yaml
+++ b/docs/demo/kserve/custom-manifests/caikit/caikit-isvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    serving.knative.openshift.io/enablePassthrough: "true"
+    sidecar.istio.io/inject: "true"
+    sidecar.istio.io/rewriteAppHTTPProbers: "true"
+  name: caikit-example-isvc
+spec:
+  predictor:
+    serviceAccountName: sa
+    model:
+      modelFormat:
+        name: caikit
+      runtime: caikit-runtime
+      storageUri: s3://modelmesh-example-models/llm/models

--- a/docs/demo/kserve/custom-manifests/caikit/caikit-servingruntime.yaml
+++ b/docs/demo/kserve/custom-manifests/caikit/caikit-servingruntime.yaml
@@ -8,7 +8,7 @@ spec:
     - name: RUNTIME_LOCAL_MODELS_DIR
       value: /mnt/models
     # TODO: This will eventually point to the official image
-    image: quay.io/spryor/caikit-serving@sha256:6c5358edc460436880d87fa40f76e1fdeb5a0410d87824c0eb8965cfde641c0d
+    image: quay.io/spryor/caikit-serving@sha256:444d2535b62e6a9a2e75d7dd490275f28f49548bdbb12923df9a676874c31d04
     name: kserve-container
     ports:
     # Note, KServe only allows a single port, this is the gRPC port. Subject to change in the future
@@ -17,8 +17,8 @@ spec:
       protocol: TCP
     resources:
       requests:
-        cpu: 8
-        memory: 16Gi
+        cpu: 4
+        memory: 8Gi
   multiModel: false
   supportedModelFormats:
   # Note: this currently *only* supports caikit format models

--- a/docs/demo/kserve/custom-manifests/minio/minio-secret.yaml
+++ b/docs/demo/kserve/custom-manifests/minio/minio-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    serving.kserve.io/s3-endpoint: minio.minio.svc:9000 # replace with your s3 endpoint e.g minio-service.kubeflow:9000
+    serving.kserve.io/s3-usehttps: "0" # by default 1, if testing with minio you can set to 0
+    serving.kserve.io/s3-region: "us-east-2"
+    serving.kserve.io/s3-useanoncredential: "false" # omitting this is the same as false, if true will ignore provided credential and use anonymous credentials
+  name: storage-config
+stringData:
+  "AWS_ACCESS_KEY_ID": "<accesskey>"
+  "AWS_SECRET_ACCESS_KEY": "<secretkey>"

--- a/docs/demo/kserve/custom-manifests/minio/minio.yaml
+++ b/docs/demo/kserve/custom-manifests/minio/minio.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - name: minio-client-port
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app: minio
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: minio
+    maistra.io/expose-route: 'true'
+  annotations:
+    sidecar.istio.io/inject: 'true'
+  name: minio
+spec:
+  containers:
+    - args:
+        - server
+        - /data1
+      env:
+        - name: MINIO_ACCESS_KEY
+          value:  THEACCESSKEY
+        - name: MINIO_SECRET_KEY
+          value: <secretkey>
+      # image: quay.io/jooholee/modelmesh-minio-examples:openvino
+      image: quay.io/jooholee/minio-examples:caikit
+      imagePullPolicy: Always
+      name: minio

--- a/docs/demo/kserve/custom-manifests/minio/serviceaccount-minio.yaml
+++ b/docs/demo/kserve/custom-manifests/minio/serviceaccount-minio.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+  annotations:
+    serving.kserve.io/s3-endpoint: minio.minio.svc:9000 # replace with your s3 endpoint e.g minio-service.kubeflow:9000
+    serving.kserve.io/s3-usehttps: "0" # by default 1, if testing with minio you can set to 0
+    serving.kserve.io/s3-region: "us-east-2"
+    serving.kserve.io/s3-useanoncredential: "false" # omitting this is the same as false, if true will ignore provided credential and use anonymous credentials
+secrets:
+- name: storage-config

--- a/docs/demo/kserve/custom-manifests/opendatahub/kfdef-kserve.yaml
+++ b/docs/demo/kserve/custom-manifests/opendatahub/kfdef-kserve.yaml
@@ -1,0 +1,30 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: kserve
+  namespace: kserve
+spec:
+  applications:
+    - kustomizeConfig:
+        parameters:
+        - name: kserve-alibi-explainer
+          value: kserve/alibi-explainer
+        - name: kserve-art-explainer
+          value: kserve/art-explainer
+        - name: kserve-agent
+          value: kserve/agent
+        - name: kserve-router
+          value: kserve/router
+        - name: kserve-storage-initializer
+          value: kserve/storage-initializer
+        - name: kserve-controller
+          value: quay.io/rlehmann/kserve-controller:v0.10.2
+        repoRef:
+          name: manifests
+          path: opendatahub/odh-manifests/kserve
+      name: kserve
+  repos:
+    - name: manifests
+      uri: file:///tmp/odh-manifests.gzip
+      # uri: https://api.github.com/repos/Jooho/kserve/tarball/manifests
+  version: master

--- a/docs/demo/kserve/custom-manifests/opendatahub/kfdef-no-plugins.yaml
+++ b/docs/demo/kserve/custom-manifests/opendatahub/kfdef-no-plugins.yaml
@@ -1,0 +1,58 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+ name: odh-mesh
+spec:
+ applications:
+ - kustomizeConfig:
+      parameters:
+        - name: namespace
+          value: istio-system
+      repoRef:
+        name: manifests
+        path: service-mesh/control-plane
+   name: control-plane
+ - kustomizeConfig:
+      overlays:
+        - service-mesh
+      repoRef:
+        name: manifests
+        path: odh-common
+   name: odh-common
+ - kustomizeConfig:
+      overlays:
+        - service-mesh
+        - dev
+      repoRef:
+        name: manifests
+        path: odh-dashboard
+   name: odh-dashboard
+ - kustomizeConfig:
+      overlays:
+        - service-mesh
+      repoRef:
+        name: manifests
+        path: odh-notebook-controller
+   name: odh-notebook-controller
+ - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odh-project-controller
+   name: odh-project-controller
+ - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: notebook-images
+   name: notebook-images
+ - kustomizeConfig:
+      parameters:
+        - name: namespace
+          value: auth-provider
+      repoRef:
+        name: manifests
+        path: service-mesh/authorino
+   name: authorino
+ repos:
+ - name: manifests
+   uri: https://github.com/maistra/odh-manifests/tarball/service-mesh-integration
+ version: service-mesh-integration

--- a/docs/demo/kserve/custom-manifests/opendatahub/kfdef-plugins.yaml
+++ b/docs/demo/kserve/custom-manifests/opendatahub/kfdef-plugins.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: odh-mesh
+  namespace: opendatahub
+spec:
+  plugins:
+    - kind: KfOssmPlugin
+      spec:
+        mesh:
+          name: minimal
+          namespace: istio-system
+          certificate:
+            generate: true
+        auth:
+          name: authorino
+          namespace: auth-provider
+          authorino:
+            topic: authorino/topic=odh
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        overlays:
+          - service-mesh
+          - dev
+        repoRef:
+          name: manifests
+          path: odh-dashboard
+      name: odh-dashboard
+    - kustomizeConfig:
+        overlays:
+          - service-mesh
+        repoRef:
+          name: manifests
+          path: odh-notebook-controller
+      name: odh-notebook-controller
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-project-controller
+      name: odh-project-controller
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: notebook-images
+      name: notebook-images
+  repos:
+    - name: manifests
+      uri: https://github.com/maistra/odh-manifests/tarball/ossm_plugin_templates
+  version: ossm_plugin_templates

--- a/docs/demo/kserve/custom-manifests/opendatahub/operators.yaml
+++ b/docs/demo/kserve/custom-manifests/opendatahub/operators.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/opendatahub-operator.openshift-operators: ""
+  name: opendatahub-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: opendatahub-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/docs/demo/kserve/custom-manifests/serverless/gateways.yaml
+++ b/docs/demo/kserve/custom-manifests/serverless/gateways.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    experimental.istio.io/disable-gateway-port-translation: "true"
+  name: knative-local-gateway
+  namespace: istio-system
+spec:
+  ports:
+    - name: http2
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    istio: ingressgateway
+  type: ClusterIP
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: knative-ingress-gateway
+  namespace: knative-serving
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - hosts:
+        - '*'
+      port:
+        name: https
+        number: 443
+        protocol: HTTPS
+      tls:
+        credentialName: wildcard-certs
+        mode: SIMPLE
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: knative-local-gateway
+  namespace: knative-serving
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - hosts:
+        - '*'
+      port:
+        name: http
+        number: 8081
+        protocol: HTTP

--- a/docs/demo/kserve/custom-manifests/serverless/operators.yaml
+++ b/docs/demo/kserve/custom-manifests/serverless/operators.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-serverless
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: serverless-operators
+  namespace: openshift-serverless
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator
+  namespace: openshift-serverless
+spec:
+  channel: stable
+  name: serverless-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/docs/demo/kserve/custom-manifests/service-mesh/operators.yaml
+++ b/docs/demo/kserve/custom-manifests/service-mesh/operators.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: servicemeshoperator
+  installPlanApproval: Automatic
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kiali-ossm
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: kiali-ossm
+  installPlanApproval: Automatic
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: jaeger-product
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: jaeger-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/docs/demo/kserve/custom-manifests/service-mesh/peer-authentication.yaml
+++ b/docs/demo/kserve/custom-manifests/service-mesh/peer-authentication.yaml
@@ -1,0 +1,8 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: opendatahub
+spec:
+  mtls:
+    mode: STRICT

--- a/docs/demo/kserve/custom-manifests/service-mesh/smcp.yaml
+++ b/docs/demo/kserve/custom-manifests/service-mesh/smcp.yaml
@@ -1,0 +1,23 @@
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: minimal
+  namespace: istio-system
+spec:
+  addons:
+    grafana:
+      enabled: false
+    kiali:
+      name: kiali
+      enabled: true
+    prometheus:
+      enabled: true
+    jaeger: 
+      name: jaeger
+  security:
+    dataPlane:
+      mtls: false # otherwise inference-graph will not work. We use PeerAuthentication resources to force mTLS
+    identity:
+      type: ThirdParty        
+  profiles:
+    - default

--- a/docs/demo/kserve/custom-manifests/service-mesh/smmr.yaml
+++ b/docs/demo/kserve/custom-manifests/service-mesh/smmr.yaml
@@ -1,0 +1,12 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRoll
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  members:
+    - knative-serving
+    - kserve
+    - kserve-demo
+    - opendatahub
+    - auth-provider

--- a/docs/demo/kserve/history.md
+++ b/docs/demo/kserve/history.md
@@ -1,0 +1,220 @@
+# ODH with OSSM enabled
+
+## Prerequisite
+- Openshift Cluster 
+  - This doc is written based on ROSA cluster
+- CLI tools
+  - oc cli
+
+- Installed operators
+  - [Kiali](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/installing-ossm.html)
+  - [Red Hat OpenShift distributed tracing platform](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/installing-ossm.html)
+  - [Red Hat OpenShift Service Mesh](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/installing-ossm.html)
+    - ServiceMeshControlPlan
+  - [Openshift Serverless](https://docs.openshift.com/serverless/1.29/install/install-serverless-operator.html)
+  - [OpenDataHub](https://opendatahub.io/docs/quick-installation/)
+  - [Authorino](https://github.com/Kuadrant/authorino-operator)
+
+## Reference
+- https://github.com/maistra/odh-manifests/blob/ossm_plugin_templates/enabling-ossm.md
+- https://github.com/ReToCode/knative-kserve#installation-with-istio--mesh
+- https://knative.dev/docs/install/operator/knative-with-operators/#create-the-knative-serving-custom-resource
+ 
+## Setup pre-requisite
+~~~
+git clone https://github.com/ReToCode/knative-kserve
+
+# Install Service Mesh operators
+oc apply -f knative-kserve/service-mesh/operators.yaml
+sleep 30
+oc wait --for=condition=ready pod -l name=istio-operator -n openshift-operators --timeout=300s
+oc wait --for=condition=ready pod -l name=jaeger-operator -n openshift-operators --timeout=300s
+oc wait --for=condition=ready pod -l name=kiali-operator -n openshift-operators --timeout=300s
+
+# Create an istio instance
+oc create ns istio-system
+oc apply -f custom-manifests/service-mesh/smcp.yaml
+sleep 15
+oc wait --for=condition=ready pod -l app=istiod -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=prometheus -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=istio-ingressgateway -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=istio-egressgateway -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=jaeger -n istio-system --timeout=300s
+
+# Install Authorino/Opendatahub operator
+oc create -f custom-manifests/authorino/operators.yaml  
+operator-sdk run bundle quay.io/maistra-dev/opendatahub-operator-bundle:v0.0.4 --namespace openshift-operators --timeout 5m0s
+#operator-sdk run bundle quay.io/cgarriso/opendatahub-operator-bundle:dev-0.0.2 --namespace openshift-operators --timeout 5m0s
+sleep 15
+oc wait --for=condition=ready pod -l control-plane=authorino-operator -n openshift-operators --timeout=300s
+oc wait --for=condition=ready pod -l control-plane=controller-manager -n openshift-operators --timeout=300s
+ 
+# Deploy opendatahub ossm
+oc create ns auth-provider
+oc create -f custom-manifests/opendatahub/kfdef-plugins.yaml
+oc wait --for condition=available kfdef --all --timeout 360s -n opendatahub
+oc wait --for condition=ready pod --all --timeout 360s opendatahub
+oc get pods -n opendatahub -o yaml | grep -q istio-proxy || oc get deployments -o name -n opendatahub | xargs -I {} oc rollout restart {} -n opendatahub
+
+# Workaround
+export TOKEN=sha256~x07wD1VrTUaFGam8FTfVcGFfEQlsFTgOH3SCvHV2mJs
+result=$(oc create -o jsonpath='{.status.audiences[0]}' -f -<<EOF
+apiVersion: authentication.k8s.io/v1
+kind: TokenReview
+spec:
+  token: "$TOKEN"
+  audiences: []
+EOF
+)
+
+kubectl patch authconfig odh-dashboard-protection -n opendatahub --type='json' -p="[{'op': 'replace', 'path': '/spec/identity/0/kubernetes/audiences', 'value': ['${result}']}]"
+
+oc adm policy add-cluster-role-to-user cluster-admin joe
+
+export ODH_ROUTE=$(oc get route --all-namespaces -l maistra.io/gateway-namespace=opendatahub -o yaml | yq '.items[].spec.host')
+xdg-open https://$ODH_ROUTE > /dev/null 2>&1 &    
+
+
+# kserve/knative
+oc create ns kserve
+oc create ns kserve-demo
+oc create ns knative-serving
+oc apply -f custom-manifests/service-mesh/smmr.yaml
+oc apply -f custom-manifests/service-mesh/peer-authentication.yaml
+oc apply -f knative-kserve/service-mesh/peer-authentication.yaml # we need this because of https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/serving#serverless-domain-mapping-custom-tls-cert_domain-mapping-custom-tls-cert
+
+oc apply -f knative-kserve/serverless/operator.yaml
+sleep 30
+oc wait --for=condition=ready pod -l name=knative-openshift -n openshift-serverless --timeout=300s
+oc wait --for=condition=ready pod -l name=knative-openshift-ingress -n openshift-serverless --timeout=300s
+oc wait --for=condition=ready pod -l name=knative-operator -n openshift-serverless --timeout=300s
+
+# Create a Knative Serving installation
+oc apply -f knative-kserve/serverless/knativeserving-istio.yaml
+sleep 15
+oc wait --for=condition=ready pod -l app=controller -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=net-istio-controller -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=net-istio-webhook -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=autoscaler-hpa -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=domain-mapping -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=webhook -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=activator -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=autoscaler -n knative-serving --timeout=300s
+
+# Create the Knative gateways
+
+git clone git@github.com:Jooho/ansible-cheat-sheet.git
+cd ansible-cheat-sheet/ansible-playbooks/ansible-playbook-generate-self-signed-cert/
+
+export COMMON_NAME=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}'|sed 's/apps.//')
+ansible-playbook ./playbook.yaml -e use_intermediate_cert=false -e cert_commonName=*.$COMMON_NAME -e cert_base_dir=/home/jooho/cert_base -b  -vvvv
+
+openssl x509 -in /home/jooho/cert_base/wild.$COMMON_NAME/wild.$COMMON_NAME.cert.pem -text
+
+oc create secret tls wildcard-certs --cert=/home/jooho/cert_base/wild.$COMMON_NAME/wild.$COMMON_NAME.cert.pem --key=/home/jooho/cert_base/wild.$COMMON_NAME/wild.$COMMON_NAME.key.pem -n istio-system
+oc apply -f custom-manifests/serverless/gateways.yaml
+
+
+# KServe Kfdef
+git clone --branch manifests git@github.com:Jooho/kserve.git
+rm -rf  custom-manifests/opendatahub/.cache  custom-manifests/opendatahub/kustomize /tmp/odh-manifests.gzip
+tar czvf /tmp/odh-manifests.gzip kserve/opendatahub/odh-manifests
+kfctl build -V -f custom-manifests/opendatahub/kfdef-kserve.yaml -d | oc create -n kserve -f -
+
+# KServe Kustomize
+#kustomize build kserve/opendatahub/odh-manifests/kserve/base/
+
+# Minio Deploy
+ACCESS_KEY_ID=THEACCESSKEY
+SECRET_ACCESS_KEY=$(openssl rand -hex 32)
+
+oc new-project minio
+sed "s/<accesskey>/$ACCESS_KEY_ID/g"  ./minio.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" | tee ./minio-current.yaml | oc -n minio apply -f -
+sed "s/<accesskey>/$ACCESS_KEY_ID/g" ./minio-secret.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" | tee ./minio-secret-current.yaml | oc -n minio apply -f - 
+
+
+# TGIS
+oc project kserve-demo
+oc apply -f ./caikit-servingruntime.yaml
+
+# Deploy model
+oc apply -f ./minio-secret-current.yaml 
+oc create -f serviceaccount-minio.yaml
+oc adm policy add-scc-to-user anyuid -z sa -n kserve-demo
+
+
+oc apply -f ./caikit-isvc.yaml
+
+
+
+
+
+
+
+
+
+
+# -insecure because the cert is self-signed in this demo environment
+# The header mm-model-id is the name of the model loaded in caikit, named the same as the directory the caikit model resides in
+
+grpcurl -insecure -d '{"text": "At what temperature does liquid Nitrogen boil?"}' -H "mm-model-id: bloom-560m" caikit-example-isvc-predictor-kserve-demo.apps.jlee-test.ugub.p1.openshiftapps.com:443 caikit.runtime.Nlp.NlpService/TextGenerationTaskPredict
+
+
+
+
+# Bootstrap process(optional)
+yum -y install git git-lfs
+git lfs install
+git clone https://huggingface.co/bigscience/bloom-560m
+
+python3 -m virtualenv venv
+source venv/bin/activate
+
+
+git clone https://github.com/Xaenalt/caikit-nlp
+python3.9 -m pip install ./caikit-nlp/   (python 3.11 can not compile)  <pip install ./caikit-nlp>
+cp ../convert.py .
+./convert.py --model-path ./bloom-560m/ --model-save-path ./bloom-560m-caikit
+
+~~~
+
+
+make docker-build
+docker tag kserve-controller:latest quay.io/jooholee/kserve-controller:latest
+docker push quay.io/jooholee/kserve-controller:latest
+
+
+
+
+
+ 
+rm -rf  kserve/opendatahub/kfdef/.cache  kserve/opendatahub/kfdef/kustomize /tmp/odh-manifests.gzip 
+tar czvf /tmp/odh-manifests.gzip kserve/opendatahub/odh-manifests
+kfctl build -V -f kserve/opendatahub/kfdef/kfdef-upstream.yaml -d | oc create -f -
+kfctl build -V -f kserve/opendatahub/kfdef/kfdef-upstream.yaml -d | oc delete -f -
+kfctl build -V -f kserve/opendatahub/kfdef/kfdef-upstream.yaml -d >/tmp/a.yaml
+ oc edit crd inferenceservices.serving.kserve.io
+
+
+
+
+
+
+`OAuth flow failed`
+~~~
+kubectl logs $(kubectl get pod -l app=oauth-openshift -n openshift-authentication -o name|head -n1) -n openshift-authentication  
+
+kubectl get oauthclient.oauth.openshift.io opendatahub-oauth2-client
+kubectl exec $(kubectl get pods -n istio-system -l app=istio-ingressgateway  -o jsonpath='{.items[*].metadata.name}') -n istio-system -c istio-proxy -- cat /etc/istio/opendatahub-oauth2-tokens/token-secret.yaml
+kubectl get secret opendatahub-oauth2-tokens -n istio-system -o yaml
+
+kubectl rollout restart deployment -n istio-system istio-ingressgateway 
+
+oc create -o yaml -f -<<EOF
+apiVersion: authentication.k8s.io/v1
+kind: TokenReview
+spec:
+  token: "$TOKEN"
+  audiences: []
+EOF
+~~~


### PR DESCRIPTION
This is an initial demo for Caikit serving runtime with serverless + service mesh.
In addition, it includes OSSM enabled opendatahub. Eventually, it will be possible to combine the two demos but it is still under development. 